### PR TITLE
[UID2-6670] Suppress GHSA-72hv-8253-57qq: jackson-core async parser not used

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -22,3 +22,7 @@ CVE-2025-66293 exp:2026-06-15
 # urllib3 vulnerabilities - requires Python 3.9+
 CVE-2025-66418 exp:2026-06-15
 CVE-2025-66471 exp:2026-06-15
+
+# jackson-core async parser DoS - not exploitable, services only use synchronous ObjectMapper API
+# See: UID2-6670
+GHSA-72hv-8253-57qq exp:2026-09-01


### PR DESCRIPTION
## Summary

Suppresses **GHSA-72hv-8253-57qq** in `.trivyignore`.

- **Vulnerability**: jackson-core: Number Length Constraint Bypass in Async Parser Leads to Potential DoS Condition
- **CVSS Score**: 8.7 (HIGH)
- **Affected range**: `com.fasterxml.jackson.core:jackson-core >= 2.0.0, <= 2.18.5`
- **Fixed in**: 2.18.6
- **Reference**: https://github.com/advisories/GHSA-72hv-8253-57qq

## Why Not Exploitable

The vulnerability is in the **async (non-blocking)** JSON parser only. This service uses only the synchronous `ObjectMapper` API (`readValue()` / `writeValueAsString()`), which is unaffected.

## Decision

Suppress in `.trivyignore` with expiry `2026-09-01`. Will revisit when jackson-core is naturally upgraded past 2.18.5.

## Jira

[UID2-6670](https://thetradedesk.atlassian.net/browse/UID2-6670)

[UID2-6670]: https://thetradedesk.atlassian.net/browse/UID2-6670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ