### PR TITLE
UID2-6681: Fix HIGH npm vulnerabilities (minimatch, serialize-javascript)

### DIFF
--- a/preview/package-lock.json
+++ b/preview/package-lock.json
@@ -12975,9 +12975,9 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
@@ -15468,14 +15468,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -16561,11 +16553,11 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/preview/package.json
+++ b/preview/package.json
@@ -52,7 +52,8 @@
   "overrides": {
     "image-size@1": "1.2.1",
     "body-parser@1": "1.20.3",
-    "minimatch": "^10.2.1",
+    "minimatch": "^10.2.3",
+    "serialize-javascript": "^7.0.3",
     "path-to-regexp@0": "0.1.12",
     "path-to-regexp@1": "1.9.0",
     "path-to-regexp@2": "8.0.0",


### PR DESCRIPTION
## Summary

Fixes HIGH severity vulnerabilities detected by Trivy in the `preview/` Docusaurus project:

- **minimatch CVE-2026-27903 & CVE-2026-27904** (HIGH): DoS via unbounded/catastrophic backtracking in glob expressions. Updated override from `^10.2.1` → `^10.2.3` (resolved: 10.2.4).
- **serialize-javascript GHSA-5c6j-r48x-rmvq** (HIGH): RCE via `RegExp.flags` and `Date.prototype.toISOString()`. Added override `^7.0.3` (resolved: 7.0.4).

## Changes

Updated `package.json` overrides and regenerated `package-lock.json` in `preview/`.

## Test plan

- [x] Verify Trivy scan passes on this branch
- [x] Verify existing CI checks pass

Jira: [UID2-6681](https://thetradedesk.atlassian.net/browse/UID2-6681)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UID2-6681]: https://thetradedesk.atlassian.net/browse/UID2-6681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ