### PR TITLE
UID2-6871: Fix CVE-2026-4800 lodash arbitrary code execution

### DIFF
--- a/preview/package-lock.json
+++ b/preview/package-lock.json
@@ -10622,9 +10622,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/preview/package.json
+++ b/preview/package.json
@@ -61,7 +61,8 @@
     "path-to-regexp@2": "8.0.0",
     "qs": "6.14.1",
     "node-forge": "^1.4.0",
-    "picomatch": "^2.3.2"
+    "picomatch": "^2.3.2",
+    "lodash": ">=4.18.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary

Fixes CVE-2026-4800 (HIGH severity) in `lodash@4.17.21` — arbitrary code execution via untrusted input in template imports.

- Adds `"lodash": ">=4.18.0"` to `overrides` in `preview/package.json`
- Regenerated lockfile now resolves lodash to `4.18.1`

## Affected paths

- `preview/package-lock.json`

## References

- CVE: https://avd.aquasec.com/nvd/cve-2026-4800
- Jira: https://thetradedesk.atlassian.net/browse/UID2-6871

🤖 Generated with [Claude Code](https://claude.com/claude-code)