### PR TITLE
UID2-6793: Pin external GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Move out of preview folder
         run: rsync -arv --exclude=".github" --exclude=".git" ./preview/ ./
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 20
           cache: npm
@@ -38,11 +38,11 @@ jobs:
       - name: Build website
         run: npm run build
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: './build'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary
- Pin all third-party GitHub Action references to full-length commit SHAs for supply chain security
- Internal IABTechLab reusable workflows and composite actions remain tag-pinned

## Test plan
- [ ] Verify CI workflows pass on this branch
- [ ] Spot-check that IABTechLab shared action references still have correct subpaths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of [UID2-6793](https://thetradedesk.atlassian.net/browse/UID2-6793)

[UID2-6793]: https://thetradedesk.atlassian.net/browse/UID2-6793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ